### PR TITLE
Update docs to provide information about the naming_convention argument

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,58 @@ where
 
 ## Get started
 
+### Naming Convention
+
+The naming_convention configuration option allows you to control the naming format for tables and columns in the plugin. This option influences how table and column names are formatted when querying Salesforce data through Steampipe. There are two supported values for the naming_convention option:
+
+- api_native :
+  If you set naming_convention to api_native, the plugin will use the native format for table names, meaning there will be no salesforce_ prefix, and the table and column names will remain as they are in Salesforce.
+
+Here's an example query using api_native naming convention in the config file:
+
+```
+select
+  "Id",
+  "WhoCount",
+  "WhatCount",
+  "Subject",
+  "IsAllDayEvent"
+from
+  "Event";
+```
+
+```
++---------------------+----------+-------------+---------+---------------+
+| ID                  | WhoCount |  WhatCount  | Subject | IsAllDayEvent |
++----------------------------------------------+-------------------------+
+| 00U2t0000000Mw3dEAD | 0        |  0          | test    | false         |
++---------------------+----------+-----------------------+---------------+
+```
+
+- snake_case :
+  If you do not specify a value for naming_convention or set it to snake_case, the plugin will use snake case for table and column names, and table names will have a salesforce_ prefix.
+
+Here's an example query using snake_case naming convention in the config file:
+
+```
+select
+  id,
+  who_count,
+  what_count,
+  subject,
+  is_all_day_event
+from
+  salesforce_event;
+```
+
+```
++---------------------+-----------+------------+---------+------------------+
+| id                  | who_count | what_count | subject | is_all_day_event |
++----------------------------------------------+----------------------------+
+| 00U2t0000000Mw3dEAD | 0         |  0         | test    | false            |
++---------------------+-----------+------------+---------+------------------+
+```
+
 ### Install
 
 Download and install the latest salesforce plugin:

--- a/docs/index.md
+++ b/docs/index.md
@@ -224,7 +224,7 @@ from
 
 ### Snake Case
 
-If you do not specify a value for `naming_convention` or set it to `snake_case`, the plugin will use snake case for table and column names, and table names will have a `salesforce*` prefix.
+If you do not specify a value for `naming_convention` or set it to `snake_case`, the plugin will use snake case for table and column names, and table names will have a `salesforce_` prefix.
 
 For example:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -224,7 +224,7 @@ from
 
 ### Snake Case
 
-If you do not specify a value for naming*convention or set it to `snake_case`, the plugin will use snake case for table and column names, and table names will have a `salesforce*` prefix.
+If you do not specify a value for `naming_convention` or set it to `snake_case`, the plugin will use snake case for table and column names, and table names will have a `salesforce*` prefix.
 
 For example:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -195,32 +195,7 @@ from
 
 ## Naming Convention
 
-The `naming_convention` configuration argument allows you to control the naming format for tables and columns in the plugin. Below are the supported values:
-
-### API Native
-
-If `naming_convention` is set to `api_native`, the plugin will use the Salesforce naming conventions. Table and column names will have mixed case and table names will not start with `salesforce_`.
-
-For example:
-
-```sql
-select
-  "Id",
-  "WhoCount",
-  "WhatCount",
-  "Subject",
-  "IsAllDayEvent"
-from
-  "Event";
-```
-
-```
-+---------------------+----------+-------------+---------+---------------+
-| ID                  | WhoCount |  WhatCount  | Subject | IsAllDayEvent |
-+----------------------------------------------+-------------------------+
-| 00U2t0000000Mw3dEAD | 0        |  0          | test    | false         |
-+---------------------+----------+-----------------------+---------------+
-```
+The `naming_convention` configuration argument allows you to control the naming format for tables and columns in the plugin.
 
 ### Snake Case
 
@@ -245,6 +220,31 @@ from
 +----------------------------------------------+----------------------------+
 | 00U2t0000000Mw3dEAD | 0         |  0         | test    | false            |
 +---------------------+-----------+------------+---------+------------------+
+```
+
+### API Native
+
+If `naming_convention` is set to `api_native`, the plugin will use Salesforce naming conventions. Table and column names will have mixed case and table names will not start with `salesforce_`.
+
+For example:
+
+```sql
+select
+  "Id",
+  "WhoCount",
+  "WhatCount",
+  "Subject",
+  "IsAllDayEvent"
+from
+  "Event";
+```
+
+```
++---------------------+----------+-------------+---------+---------------+
+| ID                  | WhoCount |  WhatCount  | Subject | IsAllDayEvent |
++----------------------------------------------+-------------------------+
+| 00U2t0000000Mw3dEAD | 0        |  0          | test    | false         |
++---------------------+----------+-----------------------+---------------+
 ```
 
 ## Get involved

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,58 +45,6 @@ where
 
 ## Get started
 
-### Naming Convention
-
-The naming_convention configuration option allows you to control the naming format for tables and columns in the plugin. This option influences how table and column names are formatted when querying Salesforce data through Steampipe. There are two supported values for the naming_convention option:
-
-- api_native :
-  If you set naming_convention to api_native, the plugin will use the native format for table names, meaning there will be no salesforce_ prefix, and the table and column names will remain as they are in Salesforce.
-
-Here's an example query using api_native naming convention in the config file:
-
-```
-select
-  "Id",
-  "WhoCount",
-  "WhatCount",
-  "Subject",
-  "IsAllDayEvent"
-from
-  "Event";
-```
-
-```
-+---------------------+----------+-------------+---------+---------------+
-| ID                  | WhoCount |  WhatCount  | Subject | IsAllDayEvent |
-+----------------------------------------------+-------------------------+
-| 00U2t0000000Mw3dEAD | 0        |  0          | test    | false         |
-+---------------------+----------+-----------------------+---------------+
-```
-
-- snake_case :
-  If you do not specify a value for naming_convention or set it to snake_case, the plugin will use snake case for table and column names, and table names will have a salesforce_ prefix.
-
-Here's an example query using snake_case naming convention in the config file:
-
-```
-select
-  id,
-  who_count,
-  what_count,
-  subject,
-  is_all_day_event
-from
-  salesforce_event;
-```
-
-```
-+---------------------+-----------+------------+---------+------------------+
-| id                  | who_count | what_count | subject | is_all_day_event |
-+----------------------------------------------+----------------------------+
-| 00U2t0000000Mw3dEAD | 0         |  0         | test    | false            |
-+---------------------+-----------+------------+---------+------------------+
-```
-
 ### Install
 
 Download and install the latest salesforce plugin:
@@ -244,6 +192,60 @@ from
 ```
 
 **Note:** Salesforce custom object names are always suffixed with `__c`, which is reflected in the table names as well.
+
+## Naming Convention
+
+The `naming_convention` configuration argument allows you to control the naming format for tables and columns in the plugin. Below are the supported values:
+
+### API Native
+
+If `naming_convention` is set to `api_native`, the plugin will use the Salesforce naming conventions. Table and column names will have mixed case and table names will not start with `salesforce_`.
+
+For example:
+
+```sql
+select
+  "Id",
+  "WhoCount",
+  "WhatCount",
+  "Subject",
+  "IsAllDayEvent"
+from
+  "Event";
+```
+
+```
++---------------------+----------+-------------+---------+---------------+
+| ID                  | WhoCount |  WhatCount  | Subject | IsAllDayEvent |
++----------------------------------------------+-------------------------+
+| 00U2t0000000Mw3dEAD | 0        |  0          | test    | false         |
++---------------------+----------+-----------------------+---------------+
+```
+
+### Snake Case
+
+If you do not specify a value for naming*convention or set it to `snake_case`, the plugin will use snake case for table and column names, and table names will have a `salesforce*` prefix.
+
+For example:
+
+```sql
+select
+  id,
+  who_count,
+  what_count,
+  subject,
+  is_all_day_event
+from
+  salesforce_event;
+```
+
+```
++---------------------+-----------+------------+---------+------------------+
+| id                  | who_count | what_count | subject | is_all_day_event |
++----------------------------------------------+----------------------------+
+| 00U2t0000000Mw3dEAD | 0         |  0         | test    | false            |
++---------------------+-----------+------------+---------+------------------+
+```
 
 ## Get involved
 

--- a/docs/tables/salesforce_account.md
+++ b/docs/tables/salesforce_account.md
@@ -2,9 +2,7 @@
 
 Represents an individual account, which is an organization or person involved with business (such as customers, competitors, and partners).
 
-If the naming_convention parameter is set to api_native in the config file, then the table and column names will match what’s in Salesforce. For instance, the query `select name, annual_revenue from salesforce_account` would become `select "Name", "AnnualRevenue" from "Account"`.
-
-Additional examples can be found [below](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_account#show_details_about_the_turbot_account).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_account#show_details_about_the_turbot_account).
 
 ## Examples
 
@@ -66,6 +64,35 @@ from
   salesforce_account
 where
   rating = 'Hot'
+```
+
+## API Native Examples
+
+### Basic info (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "Name",
+  "Description",
+  "AnnualRevenue",
+  "Ownership",
+  "Industry",
+  "Rating"
+from
+  "Account";
+```
+
+### List number of accounts by industry type (with API Native naming convention)
+
+```sql
+select
+  count(*),
+  "Industry"
+from
+  "Account"
+group by
+  "Industry";
 ```
 
 ### Show details about the turbot account

--- a/docs/tables/salesforce_account.md
+++ b/docs/tables/salesforce_account.md
@@ -2,6 +2,10 @@
 
 Represents an individual account, which is an organization or person involved with business (such as customers, competitors, and partners).
 
+If the naming_convention parameter is set to api_native in the config file, then the table and column names will match what’s in Salesforce. For instance, the query `select name, annual_revenue from salesforce_account` would become `select "Name", "AnnualRevenue" from "Account"`.
+
+Additional examples can be found [below](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_account#show_details_about_the_turbot_account).
+
 ## Examples
 
 ### Basic info
@@ -62,4 +66,38 @@ from
   salesforce_account
 where
   rating = 'Hot'
+```
+
+### Show details about the turbot account
+
+```sql
+select
+  "ID",
+  "Name",
+  "Description",
+  "AnnualRevenue",
+  "Ownership",
+  "Industry",
+  "Rating"
+from
+  "Account"
+where
+  "Name" = 'turbot';
+```
+
+### Show customer accounts
+
+```sql
+select
+  "ID",
+  "Name",
+  "Description",
+  "AnnualRevenue",
+  "Ownership",
+  "Industry",
+  "Rating"
+from
+  "Account"
+where
+  "Type" = 'Customer';
 ```

--- a/docs/tables/salesforce_account.md
+++ b/docs/tables/salesforce_account.md
@@ -2,7 +2,7 @@
 
 Represents an individual account, which is an organization or person involved with business (such as customers, competitors, and partners).
 
-If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_account#show_details_about_the_turbot_account).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_account#api_native_examples).
 
 ## Examples
 

--- a/docs/tables/salesforce_account.md
+++ b/docs/tables/salesforce_account.md
@@ -68,6 +68,8 @@ where
 
 ## API Native Examples
 
+If the `naming_convention` config argument is set to `api_native`, the table and column names will match Salesforce naming conventions.
+
 ### Basic info (with API Native naming convention)
 
 ```sql

--- a/docs/tables/salesforce_account_contact_role.md
+++ b/docs/tables/salesforce_account_contact_role.md
@@ -2,6 +2,10 @@
 
 Represents the role that a Contact plays on an Account.
 
+If the naming_convention parameter is set to api_native in the config file, then the table and column names will match what’s in Salesforce. For instance, the query `select id, account_id from salesforce_account_contact_role` would become `select "ID", "AccountID" from "AccountContactRole"`.
+
+Additional examples can be found [below](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_account_contact_role#show_approver_account_contact_roles).
+
 ## Examples
 
 ### Basic info
@@ -29,4 +33,34 @@ from
   salesforce_account_contact_role
 where
   is_primary;
+```
+
+### Show approver account contact roles
+
+```sql
+select
+  "ID",
+  "AccountID",
+  "ContactID",
+  "IsPrimary",
+  "Role"
+from
+  "AccountContactRole"
+where
+  "Role" = 'Approver';
+```
+
+### Show account contact roles created in last 30 days
+
+```sql
+select
+  "ID",
+  "AccountID",
+  "ContactID",
+  "IsPrimary",
+  "Role"
+from
+  "AccountContactRole"
+where
+  "CreatedDate" <= now() - interval '30' day;
 ```

--- a/docs/tables/salesforce_account_contact_role.md
+++ b/docs/tables/salesforce_account_contact_role.md
@@ -35,6 +35,8 @@ where
 
 ## API Native Examples
 
+If the `naming_convention` config argument is set to `api_native`, the table and column names will match Salesforce naming conventions.
+
 ### Basic info (with API Native naming convention)
 
 ```sql

--- a/docs/tables/salesforce_account_contact_role.md
+++ b/docs/tables/salesforce_account_contact_role.md
@@ -2,9 +2,7 @@
 
 Represents the role that a Contact plays on an Account.
 
-If the naming_convention parameter is set to api_native in the config file, then the table and column names will match what’s in Salesforce. For instance, the query `select id, account_id from salesforce_account_contact_role` would become `select "ID", "AccountID" from "AccountContactRole"`.
-
-Additional examples can be found [below](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_account_contact_role#show_approver_account_contact_roles).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_account_contact_role#show_approver_account_contact_roles).
 
 ## Examples
 
@@ -33,6 +31,34 @@ from
   salesforce_account_contact_role
 where
   is_primary;
+```
+
+## API Native Examples
+
+### Basic info (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "AccountID",
+  "ContactID",
+  "IsPrimary"
+from
+  "AccountContactRole";
+```
+
+### List primary account contact role (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "AccountID",
+  "ContactID",
+  "IsPrimary"
+from
+  "AccountContactRole"
+where
+  "IsPrimary";
 ```
 
 ### Show approver account contact roles

--- a/docs/tables/salesforce_account_contact_role.md
+++ b/docs/tables/salesforce_account_contact_role.md
@@ -2,7 +2,7 @@
 
 Represents the role that a Contact plays on an Account.
 
-If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_account_contact_role#show_approver_account_contact_roles).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_account_contact_role#api_native_examples).
 
 ## Examples
 

--- a/docs/tables/salesforce_asset.md
+++ b/docs/tables/salesforce_asset.md
@@ -2,6 +2,10 @@
 
 Represents an item of commercial value, such as a product sold by your company or a competitor, that a customer has purchased and installed.
 
+If the naming_convention parameter is set to api_native in the config file, then the table and column names will match what’s in Salesforce. For instance, the query `select id, name from salesforce_asset` would become `select "ID", "Name" from "Asset"`.
+
+Additional examples can be found [below](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_asset#list_shipped_assets).
+
 ## Examples
 
 ### Basic info
@@ -17,4 +21,34 @@ select
   quantity
 from
   salesforce_asset;
+```
+
+### List shipped assets
+
+```sql
+select
+  "ID",
+  "Name",
+  "Price",
+  "Status",
+  "Quantity"
+from
+  "Asset"
+where
+  "Status" = 'Shipped';
+```
+
+### List internal assets
+
+```sql
+select
+  "ID",
+  "Name",
+  "Price",
+  "Status",
+  "Quantity"
+from
+  "Asset"
+where
+  "IsInternal";
 ```

--- a/docs/tables/salesforce_asset.md
+++ b/docs/tables/salesforce_asset.md
@@ -2,9 +2,7 @@
 
 Represents an item of commercial value, such as a product sold by your company or a competitor, that a customer has purchased and installed.
 
-If the naming_convention parameter is set to api_native in the config file, then the table and column names will match what’s in Salesforce. For instance, the query `select id, name from salesforce_asset` would become `select "ID", "Name" from "Asset"`.
-
-Additional examples can be found [below](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_asset#list_shipped_assets).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_asset#list_shipped_assets).
 
 ## Examples
 
@@ -21,6 +19,21 @@ select
   quantity
 from
   salesforce_asset;
+```
+
+## API Native Examples
+
+### Basic info (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "Name",
+  "Price",
+  "Status",
+  "Quantity"
+from
+  "Asset";
 ```
 
 ### List shipped assets

--- a/docs/tables/salesforce_asset.md
+++ b/docs/tables/salesforce_asset.md
@@ -23,6 +23,8 @@ from
 
 ## API Native Examples
 
+If the `naming_convention` config argument is set to `api_native`, the table and column names will match Salesforce naming conventions.
+
 ### Basic info (with API Native naming convention)
 
 ```sql

--- a/docs/tables/salesforce_asset.md
+++ b/docs/tables/salesforce_asset.md
@@ -2,7 +2,7 @@
 
 Represents an item of commercial value, such as a product sold by your company or a competitor, that a customer has purchased and installed.
 
-If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_asset#list_shipped_assets).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_asset#api_native_examples).
 
 ## Examples
 

--- a/docs/tables/salesforce_contact.md
+++ b/docs/tables/salesforce_contact.md
@@ -2,6 +2,8 @@
 
 Represents a contact, which is a person associated with an account.
 
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_contact#list_deleted_contacts).
+
 ## Examples
 
 ### Basic info
@@ -17,4 +19,49 @@ select
   department
 from
   salesforce_contact;
+```
+
+## API Native Examples
+
+### Basic info (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "Name",
+  "AccountID",
+  "Email",
+  "Department"
+from
+  "Contact";
+```
+
+### List deleted contacts
+
+```sql
+select
+  "ID",
+  "Name",
+  "AccountID",
+  "Email",
+  "Department"
+from
+  "Contact"
+where
+  "IsDeleted";
+```
+
+### Show contacts created in last 30 days
+
+```sql
+select
+  "ID",
+  "Name",
+  "AccountID",
+  "Email",
+  "Department"
+from
+  "Contact"
+where
+  "CreatedDate" <= now() - interval '30' day;
 ```

--- a/docs/tables/salesforce_contact.md
+++ b/docs/tables/salesforce_contact.md
@@ -2,7 +2,7 @@
 
 Represents a contact, which is a person associated with an account.
 
-If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_contact#list_deleted_contacts).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_contact#api_native_examples).
 
 ## Examples
 

--- a/docs/tables/salesforce_contact.md
+++ b/docs/tables/salesforce_contact.md
@@ -23,6 +23,8 @@ from
 
 ## API Native Examples
 
+If the `naming_convention` config argument is set to `api_native`, the table and column names will match Salesforce naming conventions.
+
 ### Basic info (with API Native naming convention)
 
 ```sql

--- a/docs/tables/salesforce_contract.md
+++ b/docs/tables/salesforce_contract.md
@@ -2,6 +2,8 @@
 
 Represents a contract (a business agreement) associated with an Account.
 
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_contract#show_draft_contracts).
+
 ## Examples
 
 ### Basic info
@@ -48,4 +50,67 @@ from
   salesforce_contract
 group by
   status;
+```
+
+## API Native Examples
+
+### Basic info (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "AccountID",
+  "ContractNumber",
+  "ContractTerm",
+  "EndDate",
+  "StartDate",
+  "Status"
+from
+  "Contract";
+```
+
+### List number of contracts by status (with API Native naming convention)
+
+```sql
+select
+  count(*),
+  "Status"
+from
+  "Contract"
+group by
+  "Status";
+```
+
+### Show draft contracts
+
+```sql
+select
+  "ID",
+  "AccountID",
+  "ContractNumber",
+  "ContractTerm",
+  "EndDate",
+  "StartDate",
+  "Status"
+from
+  "Contract"
+where
+  "Status" = 'Draft';
+```
+
+### Show deleted contracts
+
+```sql
+select
+  "ID",
+  "AccountID",
+  "ContractNumber",
+  "ContractTerm",
+  "EndDate",
+  "StartDate",
+  "Status"
+from
+  "Contract"
+where
+  "IsDeleted";
 ```

--- a/docs/tables/salesforce_contract.md
+++ b/docs/tables/salesforce_contract.md
@@ -54,6 +54,8 @@ group by
 
 ## API Native Examples
 
+If the `naming_convention` config argument is set to `api_native`, the table and column names will match Salesforce naming conventions.
+
 ### Basic info (with API Native naming convention)
 
 ```sql

--- a/docs/tables/salesforce_contract.md
+++ b/docs/tables/salesforce_contract.md
@@ -2,7 +2,7 @@
 
 Represents a contract (a business agreement) associated with an Account.
 
-If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_contract#show_draft_contracts).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_contract#api_native_examples).
 
 ## Examples
 

--- a/docs/tables/salesforce_lead.md
+++ b/docs/tables/salesforce_lead.md
@@ -49,6 +49,8 @@ group by
 
 ## API Native Examples
 
+If the `naming_convention` config argument is set to `api_native`, the table and column names will match Salesforce naming conventions.
+
 ### Basic info (with API Native naming convention)
 
 ```sql

--- a/docs/tables/salesforce_lead.md
+++ b/docs/tables/salesforce_lead.md
@@ -56,7 +56,7 @@ If the `naming_convention` config argument is set to `api_native`, the table and
 ```sql
 select
   "ID",
-  "name",
+  "Name",
   "Industry",
   "IsConverted",
   "Rating",
@@ -83,7 +83,7 @@ group by
 ```sql
 select
   "ID",
-  "name",
+  "Name",
   "Industry",
   "IsConverted",
   "Rating",
@@ -100,7 +100,7 @@ where
 ```sql
 select
   "ID",
-  "name",
+  "Name",
   "Industry",
   "IsConverted",
   "Rating",

--- a/docs/tables/salesforce_lead.md
+++ b/docs/tables/salesforce_lead.md
@@ -2,7 +2,7 @@
 
 Represents a prospect or lead.
 
-If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_lead#list_cold_rated_leads).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_lead#api_native_examples).
 
 ## Examples
 

--- a/docs/tables/salesforce_lead.md
+++ b/docs/tables/salesforce_lead.md
@@ -2,6 +2,8 @@
 
 Represents a prospect or lead.
 
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_lead#list_cold_rated_leads).
+
 ## Examples
 
 ### Basic info
@@ -43,4 +45,67 @@ from
   salesforce_lead
 group by
   status;
+```
+
+## API Native Examples
+
+### Basic info (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "name",
+  "Industry",
+  "IsConverted",
+  "Rating",
+  "Status",
+  "Website"
+from
+  "Lead";
+```
+
+### List number of leads by industry type (with API Native naming convention)
+
+```sql
+select
+  count(*),
+  "Industry"
+from
+  "Lead"
+group by
+  "Industry";
+```
+
+### List cold rated leads
+
+```sql
+select
+  "ID",
+  "name",
+  "Industry",
+  "IsConverted",
+  "Rating",
+  "Status",
+  "Website"
+from
+  "Lead"
+where
+  "Rating" = 'Cold';
+```
+
+### List qualified leads
+
+```sql
+select
+  "ID",
+  "name",
+  "Industry",
+  "IsConverted",
+  "Rating",
+  "Status",
+  "Website"
+from
+  "Lead"
+where
+  "Status" = 'Qualified';
 ```

--- a/docs/tables/salesforce_object_permission.md
+++ b/docs/tables/salesforce_object_permission.md
@@ -42,6 +42,8 @@ where
 
 ## API Native Examples
 
+If the `naming_convention` config argument is set to `api_native`, the table and column names will match Salesforce naming conventions.
+
 ### Basic info (with API Native naming convention)
 
 ```sql

--- a/docs/tables/salesforce_object_permission.md
+++ b/docs/tables/salesforce_object_permission.md
@@ -2,6 +2,8 @@
 
 Represents the enabled object permissions for the parent PermissionSet.
 
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_object_permission#show_delete_permissions).
+
 ## Examples
 
 ### Basic info
@@ -36,4 +38,51 @@ from
 where
   sobject_type = 'Lead' and
   sps.id = sop.parent_id;
+```
+
+## API Native Examples
+
+### Basic info (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "ParentID",
+  "SobjectType",
+  "PermissionsModifyAllRecords",
+  "PermissionsViewAllRecords"
+from
+  "ObjectPermission"
+order by
+  "SobjectType";
+```
+
+### Show delete permissions
+
+```sql
+select
+  "ID",
+  "ParentID",
+  "SobjectType",
+  "PermissionsModifyAllRecords",
+  "PermissionsViewAllRecords"
+from
+  "ObjectPermission"
+where
+  "PermissionsDelete";
+```
+
+### Show read permissions
+
+```sql
+select
+  "ID",
+  "ParentID",
+  "SobjectType",
+  "PermissionsModifyAllRecords",
+  "PermissionsViewAllRecords"
+from
+  "ObjectPermission"
+where
+  "PermissionsRead";
 ```

--- a/docs/tables/salesforce_object_permission.md
+++ b/docs/tables/salesforce_object_permission.md
@@ -2,7 +2,7 @@
 
 Represents the enabled object permissions for the parent PermissionSet.
 
-If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_object_permission#show_delete_permissions).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_object_permission#api_native_examples).
 
 ## Examples
 

--- a/docs/tables/salesforce_opportunity.md
+++ b/docs/tables/salesforce_opportunity.md
@@ -2,6 +2,8 @@
 
 Represents an opportunity, which is a sale or pending deal.
 
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_opportunity#list_closed_opportunities).
+
 ## Examples
 
 ### Basic info
@@ -48,4 +50,73 @@ from
   salesforce_opportunity
 group by
   stage_name;
+```
+
+## API Native Examples
+
+### Basic info (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "Name",
+  "Amount",
+  "Type",
+  "StageName",
+  "ForecastCategory"
+from
+  "Opportunity"
+order by
+  "StageName";
+```
+
+### List only won opportunities (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "Name",
+  "Amount",
+  "Type",
+  "StageName",
+  "ForecastCategory",
+  "IsWon"
+from
+  "Opportunity"
+where
+  "IsWon"
+order by
+  "Amount";
+```
+
+### List closed opportunities
+
+```sql
+select
+  "ID",
+  "Name",
+  "Amount",
+  "Type",
+  "StageName",
+  "ForecastCategory"
+from
+  "Opportunity"
+where
+  "CloseDate" <= now();
+```
+
+### List opportunities with open activity
+
+```sql
+select
+  "ID",
+  "Name",
+  "Amount",
+  "Type",
+  "StageName",
+  "ForecastCategory"
+from
+  "Opportunity"
+where
+  "HasOpenActivity";
 ```

--- a/docs/tables/salesforce_opportunity.md
+++ b/docs/tables/salesforce_opportunity.md
@@ -54,6 +54,8 @@ group by
 
 ## API Native Examples
 
+If the `naming_convention` config argument is set to `api_native`, the table and column names will match Salesforce naming conventions.
+
 ### Basic info (with API Native naming convention)
 
 ```sql

--- a/docs/tables/salesforce_opportunity.md
+++ b/docs/tables/salesforce_opportunity.md
@@ -2,7 +2,7 @@
 
 Represents an opportunity, which is a sale or pending deal.
 
-If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_opportunity#list_closed_opportunities).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_opportunity#api_native_examples).
 
 ## Examples
 

--- a/docs/tables/salesforce_opportunity_contact_role.md
+++ b/docs/tables/salesforce_opportunity_contact_role.md
@@ -36,6 +36,8 @@ where
 
 ## API Native Examples
 
+If the `naming_convention` config argument is set to `api_native`, the table and column names will match Salesforce naming conventions.
+
 ### Basic info (with API Native naming convention)
 
 ```sql

--- a/docs/tables/salesforce_opportunity_contact_role.md
+++ b/docs/tables/salesforce_opportunity_contact_role.md
@@ -2,6 +2,8 @@
 
 Represents the role that a Contact plays on an Opportunity.
 
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_opportunity_contact_role#show_opportunity_contact_roles_created_in_last_30_days).
+
 ## Examples
 
 ### Basic info
@@ -30,4 +32,66 @@ from
   salesforce_opportunity_contact_role
 where
   is_primary;
+```
+
+## API Native Examples
+
+### Basic info (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "ContactID",
+  "IsPrimary",
+  "OpportunityID",
+  "StageName"
+from
+  "OpportunityContactRole";
+```
+
+### List primary opportunity contact roles (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "ContactID",
+  "IsPrimary",
+  "OpportunityID",
+  "StageName"
+from
+  "OpportunityContactRole"
+where
+  "IsPrimary";
+```
+
+### Show opportunity contact roles created in last 30 days
+
+```sql
+select
+  "ID",
+  "ContactID",
+  "IsPrimary",
+  "OpportunityID",
+  "StageName",
+  "Role"
+from
+  "OpportunityContactRole"
+where
+  "CreatedDate" <= now() - interval '30' day;
+```
+
+### Show decision maker opportunity contact roles
+
+```sql
+select
+  "ID",
+  "ContactID",
+  "IsPrimary",
+  "OpportunityID",
+  "StageName",
+  "Role"
+from
+  "OpportunityContactRole"
+where
+  "Role" = 'Decision Maker';
 ```

--- a/docs/tables/salesforce_opportunity_contact_role.md
+++ b/docs/tables/salesforce_opportunity_contact_role.md
@@ -2,7 +2,7 @@
 
 Represents the role that a Contact plays on an Opportunity.
 
-If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_opportunity_contact_role#show_opportunity_contact_roles_created_in_last_30_days).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_opportunity_contact_role#api_native_examples).
 
 ## Examples
 

--- a/docs/tables/salesforce_order.md
+++ b/docs/tables/salesforce_order.md
@@ -2,6 +2,8 @@
 
 Represents an order associated with a contract or an account.
 
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_order#list_draft_orders).
+
 ## Examples
 
 ### Basic info
@@ -29,4 +31,67 @@ from
   salesforce_order
 group by
   status;
+```
+
+## API Native Examples
+
+### Basic info (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "Name",
+  "AccountID",
+  "OrderNumber",
+  "Status",
+  "TotalAmount",
+  "Type"
+from
+  "Order";
+```
+
+### List number of orders by status (with API Native naming convention)
+
+```sql
+select
+  count(*),
+  "Status"
+from
+  "Order"
+group by
+  "Status";
+```
+
+### List draft orders
+
+```sql
+select
+  "ID",
+  "Name",
+  "AccountID",
+  "OrderNumber",
+  "Status",
+  "TotalAmount",
+  "Type"
+from
+  "Order"
+where
+  "Status" = 'Draft';
+```
+
+### List deleted orders
+
+```sql
+select
+  "ID",
+  "Name",
+  "AccountID",
+  "OrderNumber",
+  "Status",
+  "TotalAmount",
+  "Type"
+from
+  "Order"
+where
+  "IsDeleted";
 ```

--- a/docs/tables/salesforce_order.md
+++ b/docs/tables/salesforce_order.md
@@ -35,6 +35,8 @@ group by
 
 ## API Native Examples
 
+If the `naming_convention` config argument is set to `api_native`, the table and column names will match Salesforce naming conventions.
+
 ### Basic info (with API Native naming convention)
 
 ```sql

--- a/docs/tables/salesforce_order.md
+++ b/docs/tables/salesforce_order.md
@@ -2,7 +2,7 @@
 
 Represents an order associated with a contract or an account.
 
-If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_order#list_draft_orders).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_order#api_native_examples).
 
 ## Examples
 

--- a/docs/tables/salesforce_permission_set.md
+++ b/docs/tables/salesforce_permission_set.md
@@ -5,6 +5,8 @@ PermissionSet has a read-only child relationship with PermissionSetGroup. Permis
 
 **Note**: This table has one field for each permission with the pattern `permissions_permission_name`, e.g., `permissions_edit_task`. If true, users assigned to this permission set have the named permission. The number of fields varies depending on the permissions for the organization and license type.
 
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_permission_set#show_permission_sets_created_in_last_30_days).
+
 ## Examples
 
 ### Basic info
@@ -52,4 +54,68 @@ from
   salesforce_permission_set
 where
   permissions_modify_all_data;
+```
+
+## API Native Examples
+
+### Basic info (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "Name",
+  "Label",
+  "Description",
+  "IsCustom",
+  "CreatedDate"
+from
+  "PermissionSet";
+```
+
+### List non-custom permission sets (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "Name",
+  "Label",
+  "Description",
+  "IsCustom",
+  "CreatedDate"
+from
+  "PermissionSet"
+where
+  not "IsCustom";
+```
+
+### Show permission sets created in last 30 days
+
+```sql
+select
+  "ID",
+  "Name",
+  "Label",
+  "Description",
+  "IsCustom",
+  "CreatedDate"
+from
+  "PermissionSet"
+where
+  "CreatedDate" <= now() - interval '30' day;
+```
+
+### List permission sets where activation required
+
+```sql
+select
+  "ID",
+  "Name",
+  "Label",
+  "Description",
+  "IsCustom",
+  "CreatedDate"
+from
+  "PermissionSet"
+where
+  "HasActivationRequired";
 ```

--- a/docs/tables/salesforce_permission_set.md
+++ b/docs/tables/salesforce_permission_set.md
@@ -5,7 +5,7 @@ PermissionSet has a read-only child relationship with PermissionSetGroup. Permis
 
 **Note**: This table has one field for each permission with the pattern `permissions_permission_name`, e.g., `permissions_edit_task`. If true, users assigned to this permission set have the named permission. The number of fields varies depending on the permissions for the organization and license type.
 
-If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_permission_set#show_permission_sets_created_in_last_30_days).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_permission_set#api_native_examples).
 
 ## Examples
 

--- a/docs/tables/salesforce_permission_set.md
+++ b/docs/tables/salesforce_permission_set.md
@@ -58,6 +58,8 @@ where
 
 ## API Native Examples
 
+If the `naming_convention` config argument is set to `api_native`, the table and column names will match Salesforce naming conventions.
+
 ### Basic info (with API Native naming convention)
 
 ```sql

--- a/docs/tables/salesforce_permission_set_assignment.md
+++ b/docs/tables/salesforce_permission_set_assignment.md
@@ -58,6 +58,8 @@ where
 
 ## API Native Examples
 
+If the `naming_convention` config argument is set to `api_native`, the table and column names will match Salesforce naming conventions.
+
 ### Basic info (with API Native naming convention)
 
 ```sql

--- a/docs/tables/salesforce_permission_set_assignment.md
+++ b/docs/tables/salesforce_permission_set_assignment.md
@@ -2,6 +2,8 @@
 
 Represents the association between a user and permission set.
 
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_permission_set_assignment#list_assignments_which_are_not_associated_with_any_permission_set_groups).
+
 ## Examples
 
 ### Basic info
@@ -52,4 +54,32 @@ from
 where
   sps.id = spsa.permission_set_id
   and spsa.assignee_id = su.id;
+```
+
+## API Native Examples
+
+### Basic info (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "AssigneeID",
+  "PermissionSetGroupID",
+  "PermissionSetID"
+from
+  "PermissionSetAssignment";
+```
+
+### List assignments which are not associated with any permission set groups
+
+```sql
+select
+  "ID",
+  "AssigneeID",
+  "PermissionSetGroupID",
+  "PermissionSetID"
+from
+  "PermissionSetAssignment"
+where
+  "PermissionSetGroupID" is null;
 ```

--- a/docs/tables/salesforce_permission_set_assignment.md
+++ b/docs/tables/salesforce_permission_set_assignment.md
@@ -2,7 +2,7 @@
 
 Represents the association between a user and permission set.
 
-If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_permission_set_assignment#list_assignments_which_are_not_associated_with_any_permission_set_groups).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_permission_set_assignment#api_native_examples).
 
 ## Examples
 

--- a/docs/tables/salesforce_pricebook.md
+++ b/docs/tables/salesforce_pricebook.md
@@ -4,7 +4,7 @@ Represents a price book that contains the list of products that your org sells.
 
 If the naming_convention parameter is set to api_native in the config file, then the table and column names will match what’s in Salesforce. For instance, the query `select name, is_active from salesforce_pricebook` would become `select "Name", "IsActive" from "Pricebook2"`.
 
-If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_pricebook#show_archived_price_books).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_pricebook#api_native_examples).
 
 ## Examples
 

--- a/docs/tables/salesforce_pricebook.md
+++ b/docs/tables/salesforce_pricebook.md
@@ -2,6 +2,10 @@
 
 Represents a price book that contains the list of products that your org sells.
 
+If the naming_convention parameter is set to api_native in the config file, then the table and column names will match what’s in Salesforce. For instance, the query `select name, is_active from salesforce_pricebook` would become `select "Name", "IsActive" from "Pricebook2"`.
+
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_pricebook#show_archived_price_books).
+
 ## Examples
 
 ### Basic info
@@ -48,4 +52,68 @@ from
   salesforce_pricebook
 where
   is_active;
+```
+
+## API Native Examples
+
+### Basic info (with API Native naming convention)
+
+```sql
+select
+  "Name",
+  "IsActive",
+  "IsStandard",
+  "CreatedById",
+  "CreatedDate",
+  "Description"
+from
+  "Pricebook2";
+```
+
+### List standard price books (with API Native naming convention)
+
+```sql
+select
+  "Name",
+  "IsActive",
+  "IsStandard",
+  "CreatedById",
+  "CreatedDate",
+  "Description"
+from
+  "Pricebook2"
+where
+  "IsStandard";
+```
+
+## Show archived price books
+
+```sql
+select
+  "Name",
+  "IsActive",
+  "IsStandard",
+  "CreatedById",
+  "CreatedDate",
+  "Description"
+from
+  "Pricebook2"
+where
+  "IsArchived";
+```
+
+### Show deleted price books
+
+```sql
+select
+  "Name",
+  "IsActive",
+  "IsStandard",
+  "CreatedById",
+  "CreatedDate",
+  "Description"
+from
+  "Pricebook2"
+where
+  "IsDeleted";
 ```

--- a/docs/tables/salesforce_pricebook.md
+++ b/docs/tables/salesforce_pricebook.md
@@ -56,6 +56,8 @@ where
 
 ## API Native Examples
 
+If the `naming_convention` config argument is set to `api_native`, the table and column names will match Salesforce naming conventions.
+
 ### Basic info (with API Native naming convention)
 
 ```sql

--- a/docs/tables/salesforce_product.md
+++ b/docs/tables/salesforce_product.md
@@ -49,7 +49,7 @@ If the `naming_convention` config argument is set to `api_native`, the table and
 ```sql
 select
   "ID",
-  "name",
+  "Name",
   "Family",
   "IsActive",
   "StockKeepingUnit"
@@ -62,7 +62,7 @@ from
 ```sql
 select
   "ID",
-  "name",
+  "Name",
   "Family",
   "IsActive",
   "StockKeepingUnit"
@@ -77,7 +77,7 @@ where
 ```sql
 select
   "ID",
-  "name",
+  "Name",
   "Family",
   "IsActive",
   "StockKeepingUnit"
@@ -92,7 +92,7 @@ where
 ```sql
 select
   "ID",
-  "name",
+  "Name",
   "Family",
   "IsActive",
   "StockKeepingUnit"

--- a/docs/tables/salesforce_product.md
+++ b/docs/tables/salesforce_product.md
@@ -42,6 +42,8 @@ where
 
 ## API Native Examples
 
+If the `naming_convention` config argument is set to `api_native`, the table and column names will match Salesforce naming conventions.
+
 ### Basic info (with API Native naming convention)
 
 ```sql

--- a/docs/tables/salesforce_product.md
+++ b/docs/tables/salesforce_product.md
@@ -4,7 +4,7 @@ Represents a product that org sells.
 
 If the naming_convention parameter is set to api_native in the config file, then the table and column names will match what’s in Salesforce. For instance, the query `select id, name from salesforce_product` would become `select "ID", "Name" from "Product2"`.
 
-If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_product#show_archived_products).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_product#api_native_examples).
 
 ## Examples
 

--- a/docs/tables/salesforce_product.md
+++ b/docs/tables/salesforce_product.md
@@ -2,6 +2,10 @@
 
 Represents a product that org sells.
 
+If the naming_convention parameter is set to api_native in the config file, then the table and column names will match what’s in Salesforce. For instance, the query `select id, name from salesforce_product` would become `select "ID", "Name" from "Product2"`.
+
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_product#show_archived_products).
+
 ## Examples
 
 ### Basic info
@@ -34,4 +38,64 @@ from
   salesforce_product
 where
   not is_active;
+```
+
+## API Native Examples
+
+### Basic info (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "name",
+  "Family",
+  "IsActive",
+  "StockKeepingUnit"
+from
+  "Product2";
+```
+
+### List inactive products (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "name",
+  "Family",
+  "IsActive",
+  "StockKeepingUnit"
+from
+  "Product2"
+where
+  not "IsActive";
+```
+
+### Show archived products
+
+```sql
+select
+  "ID",
+  "name",
+  "Family",
+  "IsActive",
+  "StockKeepingUnit"
+from
+  "Product2"
+where
+  "IsArchived";
+```
+
+### Show deleted products
+
+```sql
+select
+  "ID",
+  "name",
+  "Family",
+  "IsActive",
+  "StockKeepingUnit"
+from
+  "Product2"
+where
+  "IsDeleted";
 ```

--- a/docs/tables/salesforce_user.md
+++ b/docs/tables/salesforce_user.md
@@ -2,6 +2,10 @@
 
 Represents a user in salesforce organization.
 
+If the naming_convention parameter is set to api_native in the config file, then the table and column names will match what’s in Salesforce. For instance, the query `select username, alias from salesforce_user` would become `select "Username", "Alias" from "User"`.
+
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_user#list_guest_users).
+
 ## Examples
 
 ### Basic info
@@ -59,4 +63,64 @@ from
   salesforce_user
 where
   forecast_enabled;
+```
+
+## API Native Examples
+
+### Basic info (with API Native naming convention)
+
+```sql
+select
+  "Username",
+  "Alias",
+  "UserType",
+  "IsActive",
+  "LastLoginDate"
+from
+  "User";
+```
+
+### List active users (with API Native naming convention)
+
+```sql
+select
+  "Username",
+  "Alias",
+  "UserType",
+  "IsActive",
+  "LastLoginDate"
+from
+  "User"
+where
+  "IsActive";
+```
+
+### List guest users
+
+```sql
+select
+  "Username",
+  "Alias",
+  "UserType",
+  "IsActive",
+  "LastLoginDate"
+from
+  "User"
+where
+  "UserType" = 'Guest';
+```
+
+### List users who logged-in in last 30 days
+
+```sql
+select
+  "Username",
+  "Alias",
+  "UserType",
+  "IsActive",
+  "LastLoginDate"
+from
+  "User"
+where
+  "LastLoginDate" <= now() - interval '30' day;
 ```

--- a/docs/tables/salesforce_user.md
+++ b/docs/tables/salesforce_user.md
@@ -4,7 +4,7 @@ Represents a user in salesforce organization.
 
 If the naming_convention parameter is set to api_native in the config file, then the table and column names will match what’s in Salesforce. For instance, the query `select username, alias from salesforce_user` would become `select "Username", "Alias" from "User"`.
 
-If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_user#list_guest_users).
+If the `naming_convention` configuration argument is set to `api_native`, please see [API Native Examples](https://hub.steampipe.io/plugins/turbot/salesforce/tables/salesforce_user#api_native_examples).
 
 ## Examples
 

--- a/docs/tables/salesforce_user.md
+++ b/docs/tables/salesforce_user.md
@@ -67,6 +67,8 @@ where
 
 ## API Native Examples
 
+If the `naming_convention` config argument is set to `api_native`, the table and column names will match Salesforce naming conventions.
+
 ### Basic info (with API Native naming convention)
 
 ```sql

--- a/docs/tables/salesforce_{object_name}.md
+++ b/docs/tables/salesforce_{object_name}.md
@@ -1,4 +1,4 @@
-# Table: salesforce_{object_name}
+# Table: salesforce\_{object_name}
 
 Query data from the object called `salesforce_{object_name}`, e.g., `salesforce_campaign`, `salesforce_custom_app__c`. A table is automatically created to represent each object in the `objects` argument.
 
@@ -115,4 +115,82 @@ from
   salesforce_custom_app__c
 where
   id = '7015j0000019GVgAAM';
+```
+
+If `naming_convention` is set to `api_native`, the plugin will use the Salesforce naming conventions. Table and column names will have mixed case and table names will not start with `salesforce_`.
+
+For instance, if the connection configuration is:
+
+```hcl
+connection "salesforce" {
+  plugin            = "salesforce"
+  url               = "https://my-dev-env.my.salesforce.com"
+  username          = "user@example.com"
+  password          = "MyPassword"
+  token             = "MyToken"
+  client_id         = "MyClientID"
+  objects           = ["Case", "Campaign", "CustomApp__c"]
+  naming_convention = "api_native"
+}
+```
+
+This plugin will automatically create tables called `Case`, `Campaign` and `CustomApp__c`:
+
+```sh
+select "ID", "OwnerID", "IsDeleted" from "CustomApp__c"
++--------------------+--------------------+------------+
+| ID                 | OwnerID            | IsDeleted  |
++--------------------+--------------------+------------+
+| a005j000006vluAAAQ | 0055j000003GU6IAAW | false      |
+| a005j000006vluBAAQ | 0055j000003GU6IAAW | false      |
+| a005j000006vluFAAQ | 0055j000003GU6IAAW | false      |
++--------------------+--------------------+------------+
+```
+
+## API Native Examples
+
+List all tables with:
+
+```sh
+.inspect salesforce
++---------------------------------+---------------------------------------------------------+
+| table                           | description                                             |
++---------------------------------+---------------------------------------------------------+
+| AccountContactRole              | Represents the role that a Contact plays on an Account. |
+| Campaign                        | Represents Saleforce object Campaign.                   |
+| Case                            | Represents Salesforce object Case.                      |
+| CustomApp__c                    | Represents Salesforce object CustomApp__c.              |
++---------------------------------+---------------------------------------------------------+
+```
+
+To get details of a specific object table, inspect it by name:
+
+```sh
+.inspect CustomApp__c
++---------------------+--------------------------+-------------------------+
+| column              | type                     | description             |
++---------------------+--------------------------+-------------------------+
+| CreatedByID         | text                     | ID of app creator.      |
+| CreatedDate         | timestamp with time zone | Created date.           |
+| ID                  | text                     | App record ID.          |
+| IsDeleted           | boolean                  | True if app is deleted. |
+| LastModifiedByID    | text                     | ID of last modifier.    |
+| LastModifiedDate    | timestamp with time zone | Last modified date.     |
+| Name                | text                     | App name.               |
+| OwnerID             | text                     | Owner ID.               |
+| SystemModstamp      | timestamp with time zone | System Modstamp.        |
++---------------------+--------------------------+-------------------------+
+```
+
+### List custom apps added in the last 24 hours (with API Native naming convention)
+
+```sql
+select
+  "ID",
+  "Name",
+  "OwnerID"
+from
+  "CustomApp__c"
+where
+  "CreatedDate" = now() - interval '24 hrs';
 ```

--- a/docs/tables/salesforce_{object_name}.md
+++ b/docs/tables/salesforce_{object_name}.md
@@ -1,4 +1,4 @@
-# Table: salesforce\_{object_name}
+# Table: salesforce_{object_name}
 
 Query data from the object called `salesforce_{object_name}`, e.g., `salesforce_campaign`, `salesforce_custom_app__c`. A table is automatically created to represent each object in the `objects` argument.
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
